### PR TITLE
feat: Implement initial Guild functionality

### DIFF
--- a/adventurers-town/script.js
+++ b/adventurers-town/script.js
@@ -5,6 +5,79 @@ const sceneBackgrounds = {
   market: 'assets/market-bg.png'
 };
 
+// Global variables
+let currentUser = null;
+let exercises = [];
+
+// User data functions
+function saveUserData(username, data) {
+    try {
+        const jsonData = JSON.stringify(data);
+        // This is a placeholder for actual file saving logic,
+        // which is not directly possible in browser-side JavaScript.
+        // In a real application, this would involve sending data to a server
+        // or using browser storage APIs (localStorage, IndexedDB).
+        localStorage.setItem(`adventurers-town-user-${username}`, jsonData);
+        console.log(`User data for ${username} saved successfully.`);
+    } catch (error) {
+        console.error(`Error saving user data for ${username}:`, error);
+    }
+}
+
+function loadUserData(username) {
+    try {
+        // Placeholder for actual file loading logic.
+        const jsonData = localStorage.getItem(`adventurers-town-user-${username}`);
+        if (jsonData) {
+            const data = JSON.parse(jsonData);
+            console.log(`User data for ${username} loaded successfully.`);
+            return data;
+        } else {
+            console.log(`No data found for user ${username}.`);
+            return null;
+        }
+    } catch (error) {
+        console.error(`Error loading user data for ${username}:`, error);
+        return null;
+    }
+}
+
+// Exercise data functions
+function saveExercises(exerciseData) {
+    try {
+        const jsonData = JSON.stringify(exerciseData);
+        // Placeholder for actual file saving logic
+        localStorage.setItem('adventurers-town-exercises', jsonData);
+        console.log('Exercises saved successfully.');
+    } catch (error) {
+        console.error('Error saving exercises:', error);
+    }
+}
+
+async function loadExercises() {
+    try {
+        // Try to load from local storage first
+        const jsonData = localStorage.getItem('adventurers-town-exercises');
+        if (jsonData) {
+            exercises = JSON.parse(jsonData);
+            console.log('Exercises loaded from local storage.');
+            return;
+        }
+
+        // If not in local storage, fetch from URL
+        const response = await fetch('https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json');
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const fetchedData = await response.json();
+        saveExercises(fetchedData); // Save fetched data to local storage
+        exercises = fetchedData;
+        console.log('Exercises fetched and saved.');
+    } catch (error) {
+        console.error('Error loading exercises:', error);
+    }
+}
+
 function setScene(sceneKey) {
   const container = document.getElementById('scene-container');
   const content = document.getElementById('scene-content');
@@ -21,8 +94,9 @@ function getSceneUI(sceneKey) {
     case 'guild':
       return `
         <div class="button-group">
-          <button class="menu-btn" onclick="console.log('Register clicked')">Register</button>
-          <button class="menu-btn" onclick="console.log('Player Card clicked')">Player Card</button>
+          <button class="menu-btn" onclick="showRegistrationForm()">Register</button>
+          <button class="menu-btn" onclick="showGuildCard()">Player Card</button>
+          <button class="menu-btn" onclick="showExerciseLogForm()">Log Exercise</button>
           <button class="menu-btn" onclick="setScene('town')">← Town</button>
         </div>
         <h1>Welcome to the Guild</h1>
@@ -46,8 +120,123 @@ function getSceneUI(sceneKey) {
   }
 }
 
+function showRegistrationForm() {
+  const content = document.getElementById('scene-content');
+  content.innerHTML = `
+    <h1>Register Account</h1>
+    <input type="text" id="usernameInput" placeholder="Enter username">
+    <button class="menu-btn" onclick="handleRegistration()">Register</button>
+    <button class="menu-btn" onclick="setScene('guild')">← Back to Guild</button>
+  `;
+}
+
+function handleRegistration() {
+  const usernameInput = document.getElementById('usernameInput');
+  const username = usernameInput.value.trim();
+
+  if (!username) {
+    alert("Username cannot be empty.");
+    return;
+  }
+
+  const existingUser = loadUserData(username);
+  if (existingUser) {
+    alert("User already exists.");
+  } else {
+    const newUserObject = {
+      username: username,
+      registeredAt: new Date().toISOString(),
+      exercises: []
+    };
+    saveUserData(username, newUserObject);
+    currentUser = newUserObject;
+    alert("Registration successful!");
+    setScene('guild');
+  }
+}
+
+function showGuildCard() {
+  if (!currentUser || !currentUser.username) {
+    alert("Please register first.");
+    return;
+  }
+
+  const content = document.getElementById('scene-content');
+  content.innerHTML = `
+    <h1>Guild Card</h1>
+    <div>Username: ${currentUser.username}</div>
+    <h2>Stats:</h2>
+    <ul>
+      <li>Upper Body Strength: 50</li>
+      <li>Lower Body Strength: 60</li>
+      <li>Core Strength: 55</li>
+      <li>Power Explosiveness: 40</li>
+      <li>Flexibility Mobility: 45</li>
+      <li>Cardio Endurance: 65</li>
+    </ul>
+    <button class="menu-btn" onclick="setScene('guild')">← Back to Guild</button>
+  `;
+}
+
+function showExerciseLogForm() {
+  if (!currentUser) {
+    alert("Please register first.");
+    return;
+  }
+
+  const content = document.getElementById('scene-content');
+  let exerciseOptions = '';
+  if (Array.isArray(exercises)) {
+    exercises.forEach(exercise => {
+      exerciseOptions += `<option value="${exercise.name}">${exercise.name}</option>`;
+    });
+  }
+
+  content.innerHTML = `
+    <h1>Log Exercise</h1>
+    <label for="exerciseSelect">Exercise Type:</label>
+    <select id="exerciseSelect">${exerciseOptions}</select>
+    <br>
+    <label for="setsInput">Sets:</label>
+    <input type="number" id="setsInput" placeholder="Enter sets">
+    <br>
+    <label for="repsInput">Reps:</label>
+    <input type="number" id="repsInput" placeholder="Enter reps">
+    <br>
+    <label for="weightInput">Weight (kg/lbs):</label>
+    <input type="number" id="weightInput" placeholder="Enter weight">
+    <br>
+    <button class="menu-btn" onclick="handleExerciseLog()">Log Exercise</button>
+    <button class="menu-btn" onclick="setScene('guild')">← Back to Guild</button>
+  `;
+}
+
+function handleExerciseLog() {
+  if (!currentUser) {
+    alert("Please register or login first."); // Should not happen if showExerciseLogForm is called correctly
+    return;
+  }
+
+  const exerciseLogEntry = {
+    date: new Date().toISOString(),
+    exerciseName: document.getElementById('exerciseSelect').value,
+    sets: parseInt(document.getElementById('setsInput').value) || 0,
+    reps: parseInt(document.getElementById('repsInput').value) || 0,
+    weight: parseFloat(document.getElementById('weightInput').value) || 0
+  };
+
+  if (!currentUser.exercises) {
+    currentUser.exercises = [];
+  }
+  currentUser.exercises.push(exerciseLogEntry);
+  saveUserData(currentUser.username, currentUser);
+
+  alert("Exercise logged!");
+  setScene('guild');
+}
 
 // Initialize the town scene on page load
 window.onload = () => {
   setScene('town');
+  loadExercises();
 };


### PR DESCRIPTION
This commit introduces the core features for the Guild in Adventurer's Town.

Implemented:
- User registration: You can now register an account with a unique username. User data is stored locally (using localStorage as a placeholder for future database integration).
- Guild Card display: Registered users can view their Guild Card, which currently displays their username and a set of placeholder stats (Upper Body Strength, Lower Body Strength, Core Strength, Power Explosiveness, Flexibility Mobility, Cardio Endurance).
- Exercise Logging: Registered users can log exercise data.
  - Exercise types are dynamically fetched from an external JSON database (https://github.com/yuhonas/free-exercise-db) on first load and cached locally (in localStorage).
  - You can select an exercise, and input sets, reps, and weight. This data is saved to your user profile.
- UI updates: The Guild scene now has interactive buttons for these new features.
- Data persistence: Basic data persistence for user accounts and exercise logs is handled via localStorage. Exercise list is also cached in localStorage after initial fetch.

File Structure Changes:
- Added `adventurers-town/data/` directory (though currently unused due to localStorage implementation for data).
- Modified `adventurers-town/script.js` extensively to support the new functionalities.