### PR TITLE
Fix: Correct button functionality in GuildPage

### DIFF
--- a/frontend/src/pages/GuildPage.jsx
+++ b/frontend/src/pages/GuildPage.jsx
@@ -23,7 +23,7 @@ const GuildPage = () => {
       }
     }
     // No 'else' needed here as redirection for non-logged-in users will be handled by App.jsx's ProtectedRoute
-  }, [currentUser, clearError, currentView]);
+  }, [currentUser, clearError]); // Removed currentView from dependencies
 
   const pageDynamicStyle = {
     backgroundImage: `url(${guildBg})`,


### PR DESCRIPTION
- I removed `currentView` from the `useEffect` dependency array in `GuildPage.jsx`.
- This change stabilizes the component's rendering cycle and prevents potential interference with UI event handling.
- Buttons for internal navigation within GuildPage (View Player Card, Log Exercise, View Exercise History) and the 'Back to Town' link should now function correctly.