### PR TITLE
Fix: Prevent re-render loop in GuildPage for UI responsiveness

### DIFF
--- a/frontend/src/pages/GuildPage.jsx
+++ b/frontend/src/pages/GuildPage.jsx
@@ -12,13 +12,12 @@ const GuildPage = () => {
   const [currentView, setCurrentView] = useState('loggedInMain');
 
   useEffect(() => {
-    // If currentUser is available, ensure errors are cleared and view is main.
-    // This effect might be redundant if App.jsx handles redirection correctly,
-    // but serves as a local reset if the component is somehow rendered while logged in.
     if (currentUser) {
       clearError();
-      // If not already on a specific sub-view, default to loggedInMain
-      if (currentView !== 'playerCard' && currentView !== 'logExercise' && currentView !== 'exerciseHistory') {
+      const isKnownSubView = currentView === 'playerCard' || currentView === 'logExercise' || currentView === 'exerciseHistory';
+      // Only set to 'loggedInMain' if it's not a known sub-view AND it's not already 'loggedInMain'.
+      // This prevents unnecessary re-renders and potential loops.
+      if (!isKnownSubView && currentView !== 'loggedInMain') {
         setCurrentView('loggedInMain');
       }
     }


### PR DESCRIPTION
The useEffect hook in GuildPage.jsx was modified to prevent it from calling setCurrentView('loggedInMain') unnecessarily when the view was already 'loggedInMain' or when transitioning between valid sub-views. This was causing a re-render loop that made Guild buttons and the 'Back to Town' link unresponsive.

The fix ensures that setCurrentView is only called to reset the view if the currentView is not a known sub-view and is not already the main Guild view. This restores UI interactivity on the Guild page.