### PR TITLE
Here's how I'll implement stat progression with current/potential, XP…

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -47,11 +47,43 @@ const UserSchema = new Schema({
   level: { type: Number, default: 1 },
   experience: { type: Number, default: 0 },
   stats: {
-    upperBodyStrength: { type: Number, default: 5 },
-    lowerBodyStrength: { type: Number, default: 5 },
-    coreStrength: { type: Number, default: 5 },
-    powerExplosiveness: { type: Number, default: 5 },
-    flexibilityMobility: { type: Number, default: 5 }
+    upperBodyStrength: {
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    },
+    lowerBodyStrength: {
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    },
+    coreStrength: {
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    },
+    powerExplosiveness: {
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    },
+    flexibilityMobility: {
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    },
+    cardioEndurance: { // Added cardioEndurance
+      current: { type: Number, default: null },
+      potential: { type: Number, default: null },
+      xp: { type: Number, default: 0 },
+      xpToNext: { type: Number, default: 0 }
+    }
+    // Vitality is intentionally omitted
   },
   titles: [String],
   achievements: [String],

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -92,9 +92,120 @@ router.get('/:id', async (req, res) => {
 
 // --- Stat Calculation Service and User Model ---
 // Ensure User model is already required at the top if not (it is in this file)
-const { calculateUserStats, fetchExerciseDb } = require('../services/statCalculationService');
+const statCalculationService = require('../services/statCalculationService');
+const { TRACKED_STATS } = require('../services/statCalculationService'); // Import TRACKED_STATS if not already available through the service object
+
+// POST /api/users/:id/exercises - (Updated to include stat and XP processing)
+router.post('/:id/exercises', async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const { type, sets, reps, weight, date } = req.body;
+
+    if (!type || sets === undefined || reps === undefined || weight === undefined) {
+      return res.status(400).json({ error: 'Missing required exercise fields: type, sets, reps, weight' });
+    }
+
+    const loggedExercise = {
+      type,
+      sets,
+      reps,
+      weight,
+      date: date ? new Date(date) : Date.now(),
+    };
+
+    user.exerciseHistory.push(loggedExercise);
+    // Don't save yet, will save after stat updates
+
+    // --- Begin Stat and XP Processing ---
+    const exerciseDbData = await statCalculationService.fetchExerciseDb();
+    if (!exerciseDbData || exerciseDbData.length === 0) {
+        return res.status(503).json({ error: 'Exercise database is currently unavailable or empty. Exercise logged but stats not updated.' });
+    }
+
+    const statWeights = await statCalculationService.loadStatWeights();
+    if (!statWeights) {
+        return res.status(503).json({ error: 'Stat weights configuration is currently unavailable. Exercise logged but stats not updated.' });
+    }
+
+    // 1. Calculate Potential Stats (and get strongest lifts)
+    const potentialResults = await statCalculationService.calculatePotentialStats(user.exerciseHistory, exerciseDbData, statWeights);
+    const { strongestLiftsByExercise, detailedContributions, ...newPotentials } = potentialResults;
+
+    // Initialize user.stats if it's not already there (should be by schema defaults, but good practice)
+    if (!user.stats) {
+        user.stats = {}; // This should align with new schema structure
+    }
+    TRACKED_STATS.forEach(statName => {
+        if (!user.stats[statName]) {
+            user.stats[statName] = { current: null, potential: null, xp: 0, xpToNext: 0};
+        }
+    });
+
+
+    // 2. Update user's potential stats and initialize current/xp if new
+    for (const statName of TRACKED_STATS) { // Iterate using TRACKED_STATS from service
+        const calculatedPotential = newPotentials[statName];
+        const userStat = user.stats[statName];
+
+        if (calculatedPotential !== null) { // Potential is calculable (>= 5 exercises)
+            if (userStat.potential === null) { // First time this stat's potential is calculated
+                userStat.potential = calculatedPotential;
+                userStat.current = Math.max(1, Math.round(0.10 * userStat.potential)); // Ensure current is at least 1
+                userStat.xp = 0;
+                userStat.xpToNext = statCalculationService.getXpToNext(userStat.current);
+            } else {
+                userStat.potential = calculatedPotential; // Update if it changed (e.g. new 1RM)
+            }
+        } else { // Potential is not calculable (< 5 exercises)
+            userStat.potential = null;
+            userStat.current = null;
+            userStat.xp = 0;
+            userStat.xpToNext = 0; // Or some indicator like Infinity if preferred
+        }
+    }
+
+    // 3. Calculate XP for the logged exercise
+    const exerciseMetadata = exerciseDbData.find(ex => ex.name.toLowerCase() === loggedExercise.type.toLowerCase());
+    let awardedXpMap = {};
+    if (exerciseMetadata) {
+        awardedXpMap = statCalculationService.calculateXpForExercise(loggedExercise, exerciseMetadata, statWeights, strongestLiftsByExercise);
+    } else {
+        console.warn(`Metadata for exercise type "${loggedExercise.type}" not found. XP cannot be calculated for this exercise.`);
+        // awardedXpMap will remain all zeros
+    }
+
+    // 4. Apply XP and Handle Level Ups
+    if (Object.keys(awardedXpMap).length > 0) {
+        user.stats = statCalculationService.applyXpAndLevelUp(user.stats, awardedXpMap);
+    }
+
+    user.markModified('stats');
+    await user.save();
+    // --- End Stat and XP Processing ---
+
+    res.status(200).json(user.exerciseHistory[user.exerciseHistory.length - 1]);
+
+  } catch (err) {
+    console.error('Error adding exercise and updating stats:', err);
+    // Check if headers sent, because some errors might happen after initial data fetch success
+    if (!res.headersSent) {
+        if (err.message.includes('Exercise database') || err.message.includes('Stat weights')) {
+             res.status(503).json({ error: `Service dependency failure: ${err.message}. Exercise logged but stats might not be fully updated.` });
+        } else {
+             res.status(500).json({ error: 'Failed to add exercise or update stats.' });
+        }
+    }
+  }
+});
+
 
 // POST /api/users/:userId/recalculate-stats - Recalculate and update user stats
+// This route might need adjustments later if we want it to fully re-initialize current stats based on new potentials,
+// or it could be deprecated in favor of incremental updates. For now, let's ensure it uses the new structures.
 router.post('/:userId/recalculate-stats', async (req, res) => {
     const { userId } = req.params;
     try {
@@ -103,50 +214,65 @@ router.post('/:userId/recalculate-stats', async (req, res) => {
             return res.status(404).json({ message: 'User not found' });
         }
 
-        // Fetch the Free Exercise DB data
-        const exerciseDbData = await fetchExerciseDb();
+        const exerciseDbData = await statCalculationService.fetchExerciseDb();
         if (!exerciseDbData || exerciseDbData.length === 0) {
-            // This indicates a problem fetching or with the DB content itself.
             return res.status(503).json({ message: 'Exercise database is currently unavailable or empty.' });
         }
-
-        const calculatedResults = await calculateUserStats(user.exerciseHistory, exerciseDbData);
-
-        // Separate the stats from detailedContributions
-        const { detailedContributions, ...newStatsFromCalc } = calculatedResults;
-
-        // Update user's stats
-        // Ensure user.stats exists, initialize if it's somehow missing
-        if (!user.stats) {
-            user.stats = {};
+        const statWeights = await statCalculationService.loadStatWeights();
+         if (!statWeights) {
+            return res.status(503).json({ error: 'Stat weights configuration is currently unavailable.' });
         }
 
-        // Update only the stats that are actually calculated and present in newStatsFromCalc
-        // This avoids accidentally wiping other potential stat fields if they exist.
-        for (const statKey in newStatsFromCalc) {
-            if (newStatsFromCalc.hasOwnProperty(statKey)) {
-                user.stats[statKey] = newStatsFromCalc[statKey];
+        // Recalculate Potentials
+        const potentialResults = await statCalculationService.calculatePotentialStats(user.exerciseHistory, exerciseDbData, statWeights);
+        const { detailedContributions, ...newPotentials } = potentialResults; // strongestLiftsByExercise not directly used here unless we reset XP
+
+        if (!user.stats) user.stats = {}; // Should be initialized by schema
+
+        for (const statName of TRACKED_STATS) {
+            const calculatedPotential = newPotentials[statName];
+            const userStat = user.stats[statName] || { current: null, potential: null, xp: 0, xpToNext: 0 }; // Ensure stat object exists
+
+            if (calculatedPotential !== null) {
+                // If potential changes, current model is that 'current' stat and 'xp' are NOT reset.
+                // They continue from where they are, towards the new potential.
+                // If a full reset of 'current' to 10% of new potential is desired, that logic would go here.
+                userStat.potential = calculatedPotential;
+
+                // If current was null (e.g. stat just became active), initialize it.
+                if (userStat.current === null) {
+                    userStat.current = Math.max(1, Math.round(0.10 * userStat.potential));
+                    userStat.xp = 0;
+                    userStat.xpToNext = statCalculationService.getXpToNext(userStat.current);
+                }
+            } else { // Potential is now null (e.g. data changed, <5 exercises)
+                userStat.potential = null;
+                userStat.current = null;
+                userStat.xp = 0;
+                userStat.xpToNext = 0;
             }
+            user.stats[statName] = userStat;
         }
 
-        // Mark 'stats' as modified because it's a mixed type schema.
-        // This tells Mongoose that the sub-document has changed.
-        user.markModified('stats');
+        // Note: This recalculate route does NOT award new XP or re-evaluate XP based on history.
+        // It primarily recalculates and updates potentials, and initializes current stats if they were null.
 
+        user.markModified('stats');
         await user.save();
 
-        // Prepare response: user data + detailed contributions
-        const userResponse = user.toJSON(); // Uses transform from UserSchema
-        userResponse.detailedContributions = detailedContributions;
+        const userResponse = user.toJSON();
+        userResponse.detailedContributions = detailedContributions; // Add contributions from potential calculation
 
         res.json({ message: 'Stats recalculated successfully.', user: userResponse });
 
     } catch (error) {
         console.error(`Error recalculating stats for user ${userId}:`, error);
-        if (error.message.includes('Could not fetch exercise database') || error.message.includes('Exercise database is currently unavailable')) {
-            res.status(503).json({ message: `Service dependency failure: ${error.message}` });
-        } else {
-            res.status(500).json({ message: 'An error occurred while recalculating stats.' });
+        if (!res.headersSent) {
+            if (error.message.includes('Could not fetch exercise database') || error.message.includes('Exercise database is currently unavailable') || error.message.includes('Stat weights')) {
+                res.status(503).json({ message: `Service dependency failure: ${error.message}` });
+            } else {
+                res.status(500).json({ message: 'An error occurred while recalculating stats.' });
+            }
         }
     }
 });

--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -96,20 +96,37 @@ const PlayerCard = () => {
       {error && !isLoadingStats && <p className="text-center text-red-400 my-3">Error calculating stats: {error}</p>}
 
       <h4 className="text-xl font-semibold text-yellow-400 mb-2 text-center">Stats:</h4>
-      <ul className="list-none p-0 space-y-1">
+      <ul className="list-none p-0 space-y-2"> {/* Increased space-y for two lines */}
         {Object.entries(stats)
-          .filter(([key]) => key !== 'id' && key !== '_id' && key !== '__v') // Filter out non-stat fields if any creep in
-          .map(([key, value], index, arr) => (
-          <li
-            key={key}
-            className={`py-2 px-3 bg-gray-700 rounded-md cursor-pointer hover:bg-gray-600 transition-colors ${index === arr.length - 1 ? '' : 'border-b border-gray-600'}`}
-            onClick={() => handleStatClick(key)}
-            title={`Click to see details for ${formatStatKey(key)}`}
-          >
-            <span className="capitalize text-gray-300">{formatStatKey(key)}: </span>
-            <span className="font-semibold text-yellow-300">{value || 0}</span>
-          </li>
-        ))}
+          .filter(([key]) => key !== 'id' && key !== '_id' && key !== '__v' && typeof stats[key] === 'object' && stats[key] !== null) // Ensure it's an object (new structure)
+          .map(([statKey, statObjValue]) => {
+            const { current, potential, xp, xpToNext } = statObjValue || {}; // Destructure with defaults
+
+            return (
+              <li
+                key={statKey}
+                className="py-2 px-3 bg-gray-700 rounded-md cursor-pointer hover:bg-gray-600 transition-colors"
+                onClick={() => handleStatClick(statKey)}
+                title={`Click to see detailed exercise contributions for ${formatStatKey(statKey)}`}
+              >
+                <div className="flex justify-between items-center">
+                  <span className="capitalize text-gray-300">{formatStatKey(statKey)}: </span>
+                  {typeof potential === 'number' ? (
+                    <span className="font-semibold text-yellow-300">
+                      {current || 0} <span className="text-xs text-gray-400">current</span> / {potential} <span className="text-xs text-gray-400">potential</span>
+                    </span>
+                  ) : (
+                    <span className="font-semibold text-gray-500">N/A</span>
+                  )}
+                </div>
+                {typeof potential === 'number' && ( // Only show XP if potential is calculated
+                  <div className="text-xs text-gray-400 mt-1">
+                    XP: {xp || 0} / {xpToNext || 'N/A'}
+                  </div>
+                )}
+              </li>
+            );
+          })}
       </ul>
 
       {selectedStatForDetails && currentUserDetailedContributions && (


### PR DESCRIPTION
…, and leveling:

- I'll update the User schema to store current, potential, xp, and xpToNext for each stat.
- I'll refactor the stat calculation service:
  - `calculatePotentialStats` (formerly `calculateUserStats`) will now determine stat potential, requiring 5 relevant exercises before a stat is considered active.
  - I'll create a new `calculateXpForExercise` function to award XP based on exercise metadata, difficulty, effort (vs 1RM), and stat weights.
  - I'll create a new `applyXpAndLevelUp` function to process XP gain, increment the current stat, and update xpToNext using a scaling formula.
  - Current stats will start at 10% of potential once potential is established.
- I'll update the exercise logging route to integrate these calculations upon new exercise entry.
- I'll update the PlayerCard frontend component to display current/potential stats and XP progress.
- I've set a global stat cap for current stats at 1000.