### PR TITLE
Fix: Export TRACKED_STATS from statCalculationService

### DIFF
--- a/backend/services/statCalculationService.js
+++ b/backend/services/statCalculationService.js
@@ -455,5 +455,6 @@ module.exports = {
     fetchExerciseDb,
     getXpToNext,
     calculateXpForExercise,
-    applyXpAndLevelUp
+    applyXpAndLevelUp,
+    TRACKED_STATS // Exporting TRACKED_STATS
 };


### PR DESCRIPTION
The TRACKED_STATS array was defined but not exported from statCalculationService.js. This caused a 'TypeError: TRACKED_STATS is not iterable' in userRoutes.js when you attempted to use it.

This commit adds TRACKED_STATS to module.exports in statCalculationService.js. This allows userRoutes.js to correctly import and iterate over it. This also enables the previously implemented stat name casing fixes to function as intended within the routes.