### PR TITLE
Fix: Ensure stat XP updates immediately on Player Card after logging …

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -187,7 +187,8 @@ router.post('/:id/exercises', async (req, res) => {
     await user.save();
     // --- End Stat and XP Processing ---
 
-    res.status(200).json(user.exerciseHistory[user.exerciseHistory.length - 1]);
+    // Return the full updated user object
+    res.status(200).json({ message: 'Exercise logged and stats updated successfully', user: user.toJSON() });
 
   } catch (err) {
     console.error('Error adding exercise and updating stats:', err);

--- a/frontend/src/components/ExerciseLogForm.jsx
+++ b/frontend/src/components/ExerciseLogForm.jsx
@@ -23,10 +23,9 @@ const ExerciseLogForm = ({ onLogSuccess }) => {
     }
     try {
       const response = await apiLogExercise(currentUser.id, { type: selectedExercise, sets: numSets, reps: numReps, weight: numWeight });
-      if (response.success && response.exercise) {
+      if (response.success && response.user) { // Expect response.user
         setMessage(response.message || 'Exercise logged!');
-        const updatedUser = { ...currentUser, exerciseHistory: [...(currentUser.exerciseHistory || []), response.exercise] };
-        loginUser(updatedUser); // Update global state
+        loginUser(response.user); // Update global state with the full user object from backend
         setSelectedExercise(''); setSets(''); setReps(''); setWeight('');
         if (onLogSuccess) onLogSuccess();
       } else { setError(response.message || 'Failed to log exercise.'); }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -59,10 +59,9 @@ export const logExercise = async (userId, exerciseData) => {
     if (!response.ok) {
       return { success: false, message: data.message || 'Failed to log exercise.' };
     }
-    // Assuming backend returns { message: '...', exercise: {...} }
-    // The global state update in ExerciseLogForm expects `response.exercise`
-    // Backend returns just the exercise object as data.
-    return { success: true, message: data.message || "Exercise logged!", exercise: data };
+    // Assuming backend returns { message: '...', user: {...} }
+    // The global state update in ExerciseLogForm will expect `response.user`
+    return { success: true, message: data.message || "Exercise logged!", user: data.user };
   } catch (error) {
     console.error('Log Exercise API error:', error);
     return { success: false, message: error.message || 'A network error occurred while logging exercise.' };


### PR DESCRIPTION
…exercise

Previously, the Player Card UI did not reliably update XP and current stats immediately after an exercise was logged. This was because the frontend was not using the comprehensive user object (with updated stats) returned from the backend after processing the new exercise.

This commit implements the following changes:

1.  **Backend (`userRoutes.js`):** The `POST /api/users/:id/exercises` endpoint now returns the complete updated user object (including recalculated stats and XP) instead of just the newly logged exercise.
2.  **Frontend Service (`api.js`):** The `logExercise` service function is updated to expect the full user object in the API response.
3.  **Frontend Component (`ExerciseLogForm.jsx`):** On successful exercise logging, the component now uses the full user object from the API response to update the global state (`currentUser`). This ensures that all parts of the application, including the Player Card, have access to the most recent stat information.
4.  **Review (`PlayerCard.jsx`):** The existing `useEffect` for `recalculateStats` was reviewed. It remains in place to handle loading detailed contributions for the stats modal, which is an acceptable secondary effect after the primary stat/XP values are immediately updated by the exercise log response.