### PR TITLE
Fix: Update frontend with user stats after logging exercise

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -26,41 +26,6 @@ router.post('/register', async (req, res) => {
   }
 });
 
-// POST /api/users/:id/exercises
-router.post('/:id/exercises', async (req, res) => {
-  try {
-    const user = await User.findById(req.params.id);
-    if (!user) {
-      return res.status(404).json({ error: 'User not found' });
-    }
-
-    const { type, sets, reps, weight, date } = req.body;
-
-    // Validate required fields
-    if (!type || sets === undefined || reps === undefined || weight === undefined) {
-      return res.status(400).json({ error: 'Missing required exercise fields: type, sets, reps, weight' });
-    }
-
-    const newExercise = {
-      type, // This corresponds to exerciseName from the frontend
-      sets,
-      reps,
-      weight,
-      date: date ? new Date(date) : Date.now(),
-    };
-
-    user.exerciseHistory.push(newExercise);
-    await user.save();
-
-    // Return the newly added exercise
-    // The exercise is the last one in the array after push
-    res.status(200).json(user.exerciseHistory[user.exerciseHistory.length - 1]);
-  } catch (err) {
-    console.error('Error adding exercise:', err);
-    res.status(500).json({ error: 'Failed to add exercise' });
-  }
-});
-
 // POST /api/users/login
 router.post('/login', async (req, res) => {
   const { email, password } = req.body;
@@ -187,7 +152,7 @@ router.post('/:id/exercises', async (req, res) => {
     await user.save();
     // --- End Stat and XP Processing ---
 
-    res.status(200).json(user.exerciseHistory[user.exerciseHistory.length - 1]);
+    res.status(200).json({ user: user.toJSON() });
 
   } catch (err) {
     console.error('Error adding exercise and updating stats:', err);

--- a/frontend/src/components/ExerciseLogForm.jsx
+++ b/frontend/src/components/ExerciseLogForm.jsx
@@ -23,10 +23,9 @@ const ExerciseLogForm = ({ onLogSuccess }) => {
     }
     try {
       const response = await apiLogExercise(currentUser.id, { type: selectedExercise, sets: numSets, reps: numReps, weight: numWeight });
-      if (response.success && response.exercise) {
+      if (response.success && response.user) {
         setMessage(response.message || 'Exercise logged!');
-        const updatedUser = { ...currentUser, exerciseHistory: [...(currentUser.exerciseHistory || []), response.exercise] };
-        loginUser(updatedUser); // Update global state
+        loginUser(response.user); // Update global state with the updated user object
         setSelectedExercise(''); setSets(''); setReps(''); setWeight('');
         if (onLogSuccess) onLogSuccess();
       } else { setError(response.message || 'Failed to log exercise.'); }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -59,10 +59,8 @@ export const logExercise = async (userId, exerciseData) => {
     if (!response.ok) {
       return { success: false, message: data.message || 'Failed to log exercise.' };
     }
-    // Assuming backend returns { message: '...', exercise: {...} }
-    // The global state update in ExerciseLogForm expects `response.exercise`
-    // Backend returns just the exercise object as data.
-    return { success: true, message: data.message || "Exercise logged!", exercise: data };
+    // The backend now returns { user: updatedUserObject }
+    return { success: true, message: "Exercise logged successfully!", user: data.user };
   } catch (error) {
     console.error('Log Exercise API error:', error);
     return { success: false, message: error.message || 'A network error occurred while logging exercise.' };


### PR DESCRIPTION
This commit fixes an issue where your stats on the frontend were not being updated after an exercise was logged. The backend now returns the entire updated user object after an exercise is logged, and the frontend uses this object to update the global state. This ensures that the Player Card always displays the most up-to-date XP and stat values.