### PR TITLE
Fix: Ensure PlayerCard re-renders on stat changes

### DIFF
--- a/frontend/src/components/PlayerCard.jsx
+++ b/frontend/src/components/PlayerCard.jsx
@@ -61,10 +61,10 @@ const PlayerCard = () => {
   useEffect(() => {
     // Recalculate stats if user is loaded and detailed contributions aren't, or if exercise history changes.
     // A more sophisticated check might involve timestamps or specific user actions.
-    if (currentUser && currentUser.id && !currentUserDetailedContributions && !isLoadingStats) {
+    if (currentUser && currentUser.id && !isLoadingStats) {
       recalculateStats(currentUser.id);
     }
-  }, [currentUser, currentUserDetailedContributions, recalculateStats, isLoadingStats]);
+  }, [currentUser, recalculateStats, isLoadingStats]);
 
   if (!currentUser) return <p className="text-center text-gray-400">Please login to view your Player Card.</p>;
 


### PR DESCRIPTION
This commit fixes an issue where the PlayerCard component was not re-rendering when your stats changed. The `useEffect` hook in `PlayerCard.jsx` was preventing the `recalculateStats` function from being called after the initial calculation. This has been fixed by removing the condition that was preventing the function from being called. This ensures that the Player Card always displays the most up-to-date XP and stat values.