### PR TITLE
Persist and turn-in quests

### DIFF
--- a/frontend/src/components/QuestBoard.jsx
+++ b/frontend/src/components/QuestBoard.jsx
@@ -247,7 +247,13 @@ const QuestBoard = () => {
         )}
       </div>
       <div className="w-1/3 max-w-sm p-4 bg-black bg-opacity-50">
-        {currentUser && <QuestLog quests={quests} />}
+        {currentUser && (
+          <QuestLog
+            quests={quests}
+            onComplete={(quest) => setCompletingQuest(quest)}
+            onAbandon={handleAbandonQuest}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/QuestLog.jsx
+++ b/frontend/src/components/QuestLog.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const QuestLog = ({ quests }) => {
+const QuestLog = ({ quests, onComplete, onAbandon }) => {
   const activeQuests = quests.filter(q => q.status === 'accepted');
 
   return (
@@ -9,9 +9,23 @@ const QuestLog = ({ quests }) => {
       {activeQuests.length > 0 ? (
         <ul>
           {activeQuests.map(quest => (
-            <li key={quest.questId} className="mb-2 p-2 bg-gray-700 rounded">
+            <li key={quest.questId} className="mb-4 p-2 bg-gray-700 rounded">
               <h3 className="font-bold text-yellow-400">{quest.title}</h3>
               <p className="text-sm text-gray-300">{quest.description}</p>
+              <div className="mt-2 flex gap-2">
+                <button
+                  onClick={() => onComplete(quest)}
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded text-sm"
+                >
+                  Complete
+                </button>
+                <button
+                  onClick={() => onAbandon(quest.questId)}
+                  className="bg-red-600 hover:bg-red-700 text-white font-bold py-1 px-2 rounded text-sm"
+                >
+                  Abandon
+                </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/frontend/src/context/GlobalState.jsx
+++ b/frontend/src/context/GlobalState.jsx
@@ -96,6 +96,8 @@ export const GlobalStateProvider = ({ children }) => {
   }, []);
 
   const updateUser = useCallback((userData) => {
+    // Persist updated user data so changes survive page refreshes
+    localStorage.setItem('currentUser', JSON.stringify(userData));
     dispatch({ type: UPDATE_USER, payload: userData });
   }, []);
 


### PR DESCRIPTION
## Summary
- persist user updates like quest status in local storage
- log completed quest exercises into history and award stats
- allow completing or abandoning quests directly from the quest log

## Testing
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm run lint` (backend) *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68bf23899904832eb1b929c630e9bd2f