### PR TITLE
Constrain quest generation to known exercises

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -48,6 +48,7 @@ const DailyQuestSchema = new Schema({
   description: { type: String, required: true },
   primaryStat: { type: String, enum: ["upperBodyStrength", "lowerBodyStrength", "coreStrength", "cardioEndurance", "flexibilityMobility", "powerExplosiveness"], required: true },
   exercises: [{
+    exerciseId: { type: String },
     name: { type: String, required: true },
     sets: { type: Number, required: true },
     reps: { type: Number },
@@ -58,6 +59,7 @@ const DailyQuestSchema = new Schema({
   expiresAt: { type: Date, required: true },
   status: { type: String, enum: ["available", "accepted", "completed", "abandoned", "expired"], default: "available" },
   userLoggedExercises: [{
+    exerciseId: { type: String },
     name: { type: String, required: true },
     sets: { type: Number, required: true },
     reps: { type: Number },

--- a/backend/services/generatePersonalDailyQuests.js
+++ b/backend/services/generatePersonalDailyQuests.js
@@ -1,309 +1,421 @@
 const OpenAI = require('openai');
-const Fuse = require('fuse.js');
 const { v4: uuidv4 } = require('uuid');
-const User = require('../models/User');
-const ExerciseAlias = require('../models/ExerciseAlias');
 const exercises = require('../data/exercises.json');
 
-const normalizeExerciseName = (value = '') =>
-  value
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+const DEFAULT_STATS_ORDER = [
+  'upperBodyStrength',
+  'lowerBodyStrength',
+  'coreStrength',
+  'cardioEndurance',
+  'flexibilityMobility',
+  'powerExplosiveness',
+];
 
-const singularizeToken = (token) => {
-  if (token.length <= 3) return token;
-  if (/ies$/.test(token)) return token.slice(0, -3) + 'y';
-  if (/ses$/.test(token) && !/sses$/.test(token)) return token.slice(0, -2);
-  if (/s$/.test(token) && !/ss$/.test(token) && !/us$/.test(token)) return token.slice(0, -1);
-  return token;
+const CATEGORY_STAT_MAP = {
+  cardio: 'cardioEndurance',
+  stretching: 'flexibilityMobility',
+  plyometrics: 'powerExplosiveness',
+  'olympic weightlifting': 'powerExplosiveness',
+  powerlifting: 'powerExplosiveness',
+  strongman: 'powerExplosiveness',
 };
 
-const getUniqueTokens = (value) => {
-  const normalized = normalizeExerciseName(value);
-  if (!normalized) {
-    return [];
-  }
-
-  return [...new Set(normalized.split(' ').filter(Boolean).map(singularizeToken))];
+const GOAL_TO_STATS = {
+  'increase upper body strength': ['upperBodyStrength'],
+  'increase lower body strength': ['lowerBodyStrength'],
+  'improve core strength': ['coreStrength'],
+  'improve cardio endurance': ['cardioEndurance'],
+  'improve flexibility mobility': ['flexibilityMobility'],
+  'improve explosive power': ['powerExplosiveness'],
+  'general fitness': DEFAULT_STATS_ORDER,
+  'weight loss': ['cardioEndurance', 'upperBodyStrength', 'lowerBodyStrength'],
+  'muscle hypertrophy (size)': ['upperBodyStrength', 'lowerBodyStrength'],
+  'active recovery / injury rehab': ['flexibilityMobility', 'cardioEndurance'],
 };
 
-const computeDiceCoefficient = (aTokens = [], bTokens = []) => {
-  if (!aTokens.length || !bTokens.length) {
-    return 0;
+const LEVEL_ORDER = {
+  beginner: 0,
+  intermediate: 1,
+  expert: 2,
+};
+
+const UPPER_BODY_MUSCLES = new Set([
+  'chest',
+  'lats',
+  'shoulders',
+  'traps',
+  'triceps',
+  'biceps',
+  'forearms',
+  'neck',
+  'middle back',
+]);
+
+const LOWER_BODY_MUSCLES = new Set([
+  'quadriceps',
+  'hamstrings',
+  'glutes',
+  'calves',
+  'adductors',
+  'abductors',
+]);
+
+const CORE_MUSCLES = new Set([
+  'abdominals',
+  'lower back',
+]);
+
+const MAX_PROMPT_EXERCISES = 40;
+const PRIORITY_STAT_LIMIT = 8;
+const GENERAL_STAT_LIMIT = 4;
+const MIN_PROMPT_EXERCISES = 12;
+
+const toLowercaseSet = (values = []) => new Set(values.filter(Boolean).map((value) => value.toLowerCase()));
+
+const categorizeExercise = (exercise) => {
+  const stats = [];
+  const categoryKey = (exercise.category || '').toLowerCase();
+  const categoryStat = CATEGORY_STAT_MAP[categoryKey];
+
+  if (categoryStat) {
+    stats.push(categoryStat);
   }
 
-  const setA = new Set(aTokens);
-  const setB = new Set(bTokens);
-  let intersection = 0;
+  let upperCount = 0;
+  let lowerCount = 0;
+  let coreCount = 0;
 
-  for (const token of setA) {
-    if (setB.has(token)) {
-      intersection += 1;
+  for (const muscle of exercise.primaryMuscles || []) {
+    const normalized = muscle.toLowerCase();
+
+    if (UPPER_BODY_MUSCLES.has(normalized)) {
+      upperCount += 1;
+    }
+
+    if (LOWER_BODY_MUSCLES.has(normalized)) {
+      lowerCount += 1;
+    }
+
+    if (CORE_MUSCLES.has(normalized)) {
+      coreCount += 1;
     }
   }
 
-  return (2 * intersection) / (setA.size + setB.size);
+  const maxCount = Math.max(upperCount, lowerCount, coreCount);
+
+  if (maxCount > 0) {
+    if (upperCount === maxCount) {
+      stats.push('upperBodyStrength');
+    }
+
+    if (lowerCount === maxCount) {
+      stats.push('lowerBodyStrength');
+    }
+
+    if (coreCount === maxCount) {
+      stats.push('coreStrength');
+    }
+  }
+
+  if (!stats.length) {
+    stats.push('upperBodyStrength');
+  }
+
+  return [...new Set(stats)];
 };
 
-const escapeRegExp = (value = '') =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const HEAVY_EQUIPMENT_TOKENS = new Set([
-  'barbell',
-  'dumbbell',
-  'machine',
-  'cable',
-  'smith',
-  'band',
-  'kettlebell',
-  'plate',
-  'resistance',
-  'bench',
-  'sled',
-  'yoke',
-  'press',
-  'curl',
-  'squat',
-  'deadlift',
-  'snatch',
-  'clean',
-  'row',
-  'pullup',
-  'chinup',
-  'dip',
-]);
-
-const CARDIO_TOKENS = new Set([
-  'walk',
-  'walking',
-  'run',
-  'running',
-  'jog',
-  'jogging',
-  'cycle',
-  'cycling',
-  'bike',
-  'biking',
-  'row',
-  'rowing',
-  'swim',
-  'swimming',
-  'cardio',
-  'sprint',
-  'skipping',
-  'jumping',
-  'climb',
-  'climbing',
-  'hike',
-  'hiking',
-]);
-
-const TOKEN_FREQUENCY_THRESHOLD = 45;
-const MATCH_CONFIDENCE_THRESHOLD = 0.45;
-
-const exerciseMatchData = exercises.map((exercise) => {
-  const tokens = getUniqueTokens(exercise.name);
-  return {
-    exercise,
-    normalizedName: normalizeExerciseName(exercise.name),
-    tokens,
-    meaningfulTokens: [],
-  };
-});
-
-const tokenFrequency = new Map();
-
-for (const entry of exerciseMatchData) {
-  for (const token of entry.tokens) {
-    tokenFrequency.set(token, (tokenFrequency.get(token) || 0) + 1);
-  }
-}
-
-for (const entry of exerciseMatchData) {
-  entry.meaningfulTokens = entry.tokens.filter(
-    (token) => (tokenFrequency.get(token) || 0) <= TOKEN_FREQUENCY_THRESHOLD
-  );
-}
-
-const exerciseNameLookup = new Map();
-
-for (const entry of exerciseMatchData) {
-  exerciseNameLookup.set(entry.exercise.name.toLowerCase(), entry);
-}
-
-const fuse = new Fuse(exerciseMatchData, {
-  keys: ['exercise.name'],
-  includeScore: true,
-  threshold: 0.45,
-  ignoreLocation: true,
-});
-
-const evaluateCandidate = (candidateEntry, context, fuseScore) => {
+const filterExercisesForUser = (preferences = {}) => {
   const {
-    tokens,
-    meaningfulTokens,
-    normalizedInput,
-    inputHasHeavyToken,
-    inputHasCardioToken,
-  } = context;
+    excludedExercises = [],
+    excludedEquipment = [],
+    excludedMuscles = [],
+  } = preferences;
 
-  const baseScore = 1 - fuseScore;
-  const tokenDice = computeDiceCoefficient(tokens, candidateEntry.tokens);
-  const meaningfulDice = computeDiceCoefficient(meaningfulTokens, candidateEntry.meaningfulTokens);
-  const sharedMeaningfulCount = meaningfulTokens.filter((token) =>
-    candidateEntry.tokens.includes(token)
-  ).length;
+  const excludedExerciseNames = toLowercaseSet(excludedExercises);
+  const excludedEquipmentSet = toLowercaseSet(excludedEquipment);
+  const excludedMusclesSet = toLowercaseSet(excludedMuscles);
 
-  let combinedScore = baseScore * 0.5 + tokenDice * 0.3 + meaningfulDice * 0.2;
+  let filtered = exercises.filter((exercise) => {
+    if (excludedExerciseNames.has(exercise.name.toLowerCase())) {
+      return false;
+    }
 
-  if (meaningfulTokens.length > 0 && sharedMeaningfulCount === 0) {
-    combinedScore -= 0.2;
+    if (excludedEquipmentSet.size && exercise.equipment && excludedEquipmentSet.has(exercise.equipment.toLowerCase())) {
+      return false;
+    }
+
+    if (
+      excludedMusclesSet.size &&
+      (exercise.primaryMuscles || []).some((muscle) => excludedMusclesSet.has(muscle.toLowerCase()))
+    ) {
+      return false;
+    }
+
+    return true;
+  });
+
+  if (!filtered.length) {
+    filtered = exercises.filter((exercise) => !excludedExerciseNames.has(exercise.name.toLowerCase()));
   }
 
-  if (meaningfulTokens.length > 0 && meaningfulTokens.every((token) => candidateEntry.tokens.includes(token))) {
-    combinedScore += 0.05;
+  if (!filtered.length) {
+    filtered = [...exercises];
   }
 
-  if (normalizedInput && candidateEntry.normalizedName.includes(normalizedInput)) {
-    combinedScore += 0.05;
+  return filtered
+    .map((exercise) => {
+      const statOptions = categorizeExercise(exercise);
+      return {
+        exercise,
+        statOptions,
+        primaryStat: statOptions[0],
+      };
+    })
+    .sort((a, b) => a.exercise.name.localeCompare(b.exercise.name));
+};
+
+const determinePriorityStats = (trainingGoals = []) => {
+  const stats = new Set();
+
+  for (const goal of trainingGoals) {
+    const normalized = (goal || '').toLowerCase();
+    const mapped = GOAL_TO_STATS[normalized];
+
+    if (mapped) {
+      mapped.forEach((stat) => stats.add(stat));
+    }
   }
 
-  if (normalizedInput && normalizedInput.includes(candidateEntry.normalizedName)) {
-    combinedScore += 0.05;
+  if (!stats.size) {
+    DEFAULT_STATS_ORDER.forEach((stat) => stats.add(stat));
   }
 
-  const candidateHasHeavyToken = candidateEntry.tokens.some((token) => HEAVY_EQUIPMENT_TOKENS.has(token));
-  const candidateHasCardioToken = candidateEntry.tokens.some((token) => CARDIO_TOKENS.has(token));
+  return stats;
+};
 
-  if (!inputHasHeavyToken && candidateHasHeavyToken && tokenDice < 0.6) {
-    combinedScore -= 0.08;
+const formatExerciseForPrompt = (exercise) => ({
+  exerciseId: exercise.id,
+  name: exercise.name,
+  equipment: exercise.equipment || 'body only',
+  category: exercise.category,
+  primaryMuscles: (exercise.primaryMuscles || []).slice(0, 3),
+  level: exercise.level,
+});
+
+const selectExercisesForPrompt = (filteredExercises, priorityStats) => {
+  const groupedByStat = new Map();
+
+  for (const item of filteredExercises) {
+    const statKey = item.primaryStat || 'upperBodyStrength';
+
+    if (!groupedByStat.has(statKey)) {
+      groupedByStat.set(statKey, []);
+    }
+
+    groupedByStat.get(statKey).push(item);
   }
 
-  if (inputHasCardioToken && candidateHasCardioToken) {
-    combinedScore += 0.04;
+  for (const [statKey, list] of groupedByStat.entries()) {
+    list.sort((a, b) => {
+      const aLevel = LEVEL_ORDER[(a.exercise.level || '').toLowerCase()] ?? Number.MAX_SAFE_INTEGER;
+      const bLevel = LEVEL_ORDER[(b.exercise.level || '').toLowerCase()] ?? Number.MAX_SAFE_INTEGER;
+
+      if (aLevel !== bLevel) {
+        return aLevel - bLevel;
+      }
+
+      return a.exercise.name.localeCompare(b.exercise.name);
+    });
   }
 
-  combinedScore = Math.max(0, Math.min(1, combinedScore));
+  const summary = {};
+  const usedIds = new Set();
+  const selectedItems = [];
+
+  for (const stat of DEFAULT_STATS_ORDER) {
+    summary[stat] = [];
+  }
+
+  const pickForStat = (stat, limit) => {
+    const list = groupedByStat.get(stat) || [];
+
+    for (const item of list) {
+      if (selectedItems.length >= MAX_PROMPT_EXERCISES) {
+        break;
+      }
+
+      if (summary[stat].length >= limit) {
+        break;
+      }
+
+      if (usedIds.has(item.exercise.id)) {
+        continue;
+      }
+
+      summary[stat].push(formatExerciseForPrompt(item.exercise));
+      usedIds.add(item.exercise.id);
+      selectedItems.push(item);
+    }
+  };
+
+  for (const stat of DEFAULT_STATS_ORDER) {
+    if (priorityStats.has(stat)) {
+      pickForStat(stat, PRIORITY_STAT_LIMIT);
+    }
+  }
+
+  for (const stat of DEFAULT_STATS_ORDER) {
+    if (!priorityStats.has(stat)) {
+      pickForStat(stat, GENERAL_STAT_LIMIT);
+    }
+  }
+
+  if (selectedItems.length < MIN_PROMPT_EXERCISES) {
+    for (const item of filteredExercises) {
+      if (selectedItems.length >= MAX_PROMPT_EXERCISES) {
+        break;
+      }
+
+      if (usedIds.has(item.exercise.id)) {
+        continue;
+      }
+
+      const stat = item.primaryStat || 'upperBodyStrength';
+      summary[stat].push(formatExerciseForPrompt(item.exercise));
+      usedIds.add(item.exercise.id);
+      selectedItems.push(item);
+    }
+  }
 
   return {
-    candidateEntry,
-    combinedScore,
-    fuseScore,
+    promptSummary: summary,
+    promptExercises: selectedItems,
   };
 };
 
-const gatherSearchResults = (rawQuery, normalizedQuery) => {
-  const resultsByName = new Map();
+const buildPrompt = ({
+  trainingGoals,
+  excludedMuscles,
+  excludedEquipment,
+  excludedExercises,
+  customInstructions,
+  recentExerciseHistory,
+  stats,
+  allowedExercisesSnippet,
+  priorityStats,
+}) => {
+  const priorityStatList = Array.from(priorityStats);
+  const promptLines = [
+    'You are a master game designer creating personalized fitness quests for a user in a gamified fitness app.',
+    'Generate 3 to 5 RPG-style workout quests based on the following user data:',
+    '',
+    'User Profile:',
+    `- Training Goals: ${trainingGoals.length ? trainingGoals.join(', ') : 'None specified'}`,
+    `- Excluded Muscles: ${excludedMuscles.length ? excludedMuscles.join(', ') : 'None'}`,
+    `- Excluded Equipment: ${excludedEquipment.length ? excludedEquipment.join(', ') : 'None'}`,
+    `- Excluded Exercises: ${excludedExercises.length ? excludedExercises.join(', ') : 'None'}`,
+    `- Custom Instructions: ${customInstructions || 'None'}`,
+    `- Recent Exercise History (last 30 days): ${JSON.stringify(recentExerciseHistory, null, 2)}`,
+    `- Current Stat Levels: ${JSON.stringify(stats, null, 2)}`,
+    priorityStatList.length
+      ? `- Priority Stats to Emphasize: ${priorityStatList.join(', ')}`
+      : '- Priority Stats to Emphasize: None (use balanced variety)',
+    '',
+    'Allowed Exercises (select only from this list; reference "exerciseId" exactly as shown):',
+    allowedExercisesSnippet,
+    '',
+    'Important rules:',
+    '1. Use only exercises from the allowed list. Copy the provided "name" and include the matching "exerciseId" for each exercise.',
+    '2. Each quest must include 1 to 3 exercises with numeric "sets" and either "reps" (for strength/power work) or "duration" in seconds (for cardio/stretching).',
+    '3. Keep recommendations aligned with the user\'s goals, respecting all exclusions and instructions.',
+    '4. Return a valid JSON object with a top-level "quests" array. Do not include any extra commentary before or after the JSON.',
+    '5. Each exercise object in the response must include: exerciseId, name, sets, and either reps or duration. weightPercent is optional but, if present, must be a positive number.',
+  ];
 
-  const pushResults = (query) => {
-    if (!query) {
-      return;
-    }
-
-    for (const result of fuse.search(query)) {
-      const key = result.item.exercise.name;
-      const existing = resultsByName.get(key);
-
-      if (!existing || result.score < existing.score) {
-        resultsByName.set(key, result);
-      }
-    }
-  };
-
-  pushResults(rawQuery);
-
-  if (normalizedQuery && normalizedQuery !== rawQuery) {
-    pushResults(normalizedQuery);
-  }
-
-  return Array.from(resultsByName.values()).sort((a, b) => a.score - b.score);
+  return promptLines.join('\n');
 };
 
-const findExerciseMatch = async (exerciseName) => {
-  if (!exerciseName) {
+const parsePositiveInteger = (value) => {
+  const numeric = Number(value);
+
+  if (!Number.isFinite(numeric) || numeric <= 0) {
     return null;
   }
 
-  const normalizedInput = normalizeExerciseName(exerciseName);
-  const tokens = getUniqueTokens(exerciseName);
-  const meaningfulTokens = tokens.filter(
-    (token) => (tokenFrequency.get(token) || 0) <= TOKEN_FREQUENCY_THRESHOLD
-  );
-  const inputHasHeavyToken = tokens.some((token) => HEAVY_EQUIPMENT_TOKENS.has(token));
-  const inputHasCardioToken = tokens.some((token) => CARDIO_TOKENS.has(token));
+  return Math.round(numeric);
+};
 
-  const directMatch = exerciseNameLookup.get(exerciseName.toLowerCase());
+const parsePositiveNumber = (value) => {
+  const numeric = Number(value);
 
-  if (directMatch) {
-    return {
-      matchedExercise: directMatch.exercise,
-      matchType: 'exact-name',
-      confidence: 1,
-      normalizedOriginalName: normalizedInput,
-    };
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
   }
 
-  const aliasMatch = await ExerciseAlias.findOne({
-    $or: [
-      { normalizedOriginalName: normalizedInput },
-      { originalName: { $regex: new RegExp(`^${escapeRegExp(exerciseName)}$`, 'i') } },
-    ],
-  }).lean();
+  return Math.round(numeric * 100) / 100;
+};
 
-  if (aliasMatch) {
-    const aliasExerciseEntry = exerciseNameLookup.get(aliasMatch.matchedName.toLowerCase());
+const sanitizeExerciseFromModel = (exercise, allowedExerciseMap) => {
+  if (!exercise || typeof exercise !== 'object') {
+    return null;
+  }
 
-    if (aliasExerciseEntry) {
-      return {
-        matchedExercise: aliasExerciseEntry.exercise,
-        matchType: 'alias',
-        confidence: 1 - (aliasMatch.confidenceScore ?? 0),
-        normalizedOriginalName: normalizedInput,
-        aliasDocument: aliasMatch,
-      };
+  const exerciseId = exercise.exerciseId;
+
+  if (!exerciseId || typeof exerciseId !== 'string') {
+    return null;
+  }
+
+  const allowed = allowedExerciseMap.get(exerciseId);
+
+  if (!allowed) {
+    return null;
+  }
+
+  const sets = parsePositiveInteger(exercise.sets);
+
+  if (sets === null) {
+    return null;
+  }
+
+  const reps = exercise.reps !== undefined ? parsePositiveInteger(exercise.reps) : null;
+  const duration = exercise.duration !== undefined ? parsePositiveInteger(exercise.duration) : null;
+  const category = (allowed.exercise.category || '').toLowerCase();
+  const requiresDuration = category === 'cardio' || category === 'stretching';
+
+  if (requiresDuration) {
+    if (duration === null) {
+      return null;
     }
-  }
-
-  if (!tokens.length) {
+  } else if (reps === null) {
     return null;
   }
 
-  const searchResults = gatherSearchResults(exerciseName, normalizedInput).slice(0, 20);
-
-  if (searchResults.length === 0) {
-    return null;
-  }
-
-  const context = {
-    tokens,
-    meaningfulTokens,
-    normalizedInput,
-    inputHasHeavyToken,
-    inputHasCardioToken,
+  const sanitized = {
+    exerciseId: allowed.exercise.id,
+    name: allowed.exercise.name,
+    sets,
   };
 
-  let bestMatch = null;
+  if (reps !== null) {
+    sanitized.reps = reps;
+  }
 
-  for (const result of searchResults) {
-    const evaluation = evaluateCandidate(result.item, context, result.score);
+  if (duration !== null) {
+    sanitized.duration = duration;
+  }
 
-    if (!bestMatch || evaluation.combinedScore > bestMatch.combinedScore) {
-      bestMatch = evaluation;
+  if (exercise.weightPercent !== undefined && exercise.weightPercent !== null) {
+    const weightPercent = parsePositiveNumber(exercise.weightPercent);
+
+    if (weightPercent === null) {
+      return null;
     }
+
+    sanitized.weightPercent = weightPercent;
   }
 
-  if (bestMatch && bestMatch.combinedScore >= MATCH_CONFIDENCE_THRESHOLD) {
-    return {
-      matchedExercise: bestMatch.candidateEntry.exercise,
-      matchType: 'fuzzy',
-      confidence: bestMatch.combinedScore,
-      normalizedOriginalName: normalizedInput,
-    };
-  }
-
-  return null;
+  return sanitized;
 };
 
 const generatePersonalDailyQuests = async (user) => {
@@ -317,70 +429,65 @@ const generatePersonalDailyQuests = async (user) => {
   const openai = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  console.log('User:', JSON.stringify(user, null, 2));
 
-  // 1. Gather user data
-  const { preferences, exerciseHistory, stats } = user;
+  const { preferences = {}, exerciseHistory = [], stats = {} } = user;
   const {
-    trainingGoals,
-    excludedMuscles,
-    excludedEquipment,
-    excludedExercises,
-    customInstructions,
+    trainingGoals = [],
+    excludedMuscles = [],
+    excludedEquipment = [],
+    excludedExercises = [],
+    customInstructions = '',
   } = preferences;
 
-  const recentExerciseHistory = exerciseHistory.filter(entry => {
+  const recentExerciseHistory = exerciseHistory.filter((entry) => {
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
     return new Date(entry.date) > thirtyDaysAgo;
   });
 
-  // 2. Construct the prompt
-  const prompt = `
-    You are a master game designer creating personalized fitness quests for a user in a gamified fitness app.
-    Generate 3 to 5 RPG-style workout quests based on the following user data:
+  const filteredExercises = filterExercisesForUser(preferences);
+  const priorityStats = determinePriorityStats(trainingGoals);
+  const { promptSummary, promptExercises } = selectExercisesForPrompt(filteredExercises, priorityStats);
+  const allowedExerciseMap = new Map(promptExercises.map((item) => [item.exercise.id, item]));
+  const allowedExercisesSnippet = JSON.stringify(promptSummary, null, 2);
 
-    User Profile:
-    - Training Goals: ${trainingGoals.join(', ')}
-    - Excluded Muscles: ${excludedMuscles.join(', ')}
-    - Excluded Equipment: ${excludedEquipment.join(', ')}
-    - Excluded Exercises: ${excludedExercises.join(', ')}
-    - Custom Instructions: ${customInstructions}
-    - Recent Exercise History (last 30 days): ${JSON.stringify(recentExerciseHistory, null, 2)}
-    - Current Stat Levels: ${JSON.stringify(stats, null, 2)}
+  console.log('Allowed exercise pool size:', promptExercises.length);
 
-    Please return the quests in a valid JSON array format, under a "quests" key. Each quest object in the array must include:
-    - title: A creative and engaging title for the quest (e.g., "The Gauntlet of Strength", "Serpent's Stretch").
-    - rank: A difficulty rank from "G" (easiest) to "S" (hardest).
-    - description: Flavorful text that makes the workout sound like an epic adventure.
-    - primaryStat: The main stat this quest will improve (one of: "upperBodyStrength", "lowerBodyStrength", "coreStrength", "cardioEndurance", "flexibilityMobility", "powerExplosiveness").
-    - exercises: An array of 1 to 3 exercise objects. Each exercise object must have:
-      - name: The name of the exercise.
-      - sets: The number of sets.
-      - reps: The number of repetitions (for strength exercises).
-      - duration: The duration in seconds (for stretching or cardio exercises).
-      - weightPercent: (Optional) A percentage of the user's 1RM for weighted exercises.
+  const prompt = buildPrompt({
+    trainingGoals,
+    excludedMuscles,
+    excludedEquipment,
+    excludedExercises,
+    customInstructions,
+    recentExerciseHistory,
+    stats,
+    allowedExercisesSnippet,
+    priorityStats,
+  });
 
-    Ensure the generated JSON is valid and follows the specified structure. Do not include any extra text or explanations outside of the JSON array.
-  `;
   console.log('--- Prompt for OpenAI ---');
   console.log(prompt);
 
   try {
-    // 3. Send the prompt to GPT-4
     const response = await openai.chat.completions.create({
       model: 'gpt-4o',
       messages: [{ role: 'user', content: prompt }],
-      response_format: { type: "json_object" },
+      response_format: { type: 'json_object' },
     });
 
     console.log('--- Raw Response from OpenAI ---');
     console.log(JSON.stringify(response, null, 2));
 
-    const quests = JSON.parse(response.choices[0].message.content).quests;
+    const content = response.choices?.[0]?.message?.content;
 
-    // 4. Parse and validate the LLM response
-    if (!quests || !Array.isArray(quests)) {
+    if (!content) {
+      throw new Error('OpenAI response did not include content.');
+    }
+
+    const parsed = JSON.parse(content);
+    const quests = parsed.quests;
+
+    if (!Array.isArray(quests)) {
       console.error('Invalid response from OpenAI: "quests" array not found or not an array.');
       throw new Error('Invalid response from OpenAI');
     }
@@ -391,107 +498,66 @@ const generatePersonalDailyQuests = async (user) => {
     const validatedQuests = [];
 
     for (const quest of quests) {
+      if (!quest || typeof quest !== 'object') {
+        continue;
+      }
+
+      if (!quest.title || !quest.rank || !quest.description || !quest.primaryStat) {
+        continue;
+      }
+
+      if (!Array.isArray(quest.exercises) || quest.exercises.length === 0) {
+        continue;
+      }
+
       let questIsValid = true;
       const validatedExercises = [];
 
       for (const exercise of quest.exercises) {
-        const match = await findExerciseMatch(exercise.name);
+        const sanitized = sanitizeExerciseFromModel(exercise, allowedExerciseMap);
 
-        if (!match || !match.matchedExercise) {
+        if (!sanitized) {
           questIsValid = false;
-          console.log(`No confident match for exercise: ${exercise.name}. Discarding quest: "${quest.title}"`);
+          console.log(`Rejected exercise due to validation failure: ${JSON.stringify(exercise)}`);
           break;
         }
 
-        validatedExercises.push({ ...exercise, name: match.matchedExercise.name });
-
-        if (match.matchType === 'fuzzy') {
-          const normalizedOriginalName =
-            match.normalizedOriginalName || normalizeExerciseName(exercise.name);
-          const matchedNameLower = match.matchedExercise.name.toLowerCase();
-          const confidenceScore = Math.max(0, 1 - match.confidence);
-          const aliasFilter = {
-            $or: [
-              { normalizedOriginalName, matchedNameLower },
-              {
-                originalName: { $regex: new RegExp(`^${escapeRegExp(exercise.name)}$`, 'i') },
-                matchedName: match.matchedExercise.name,
-              },
-            ],
-          };
-          const aliasPayload = {
-            originalName: exercise.name,
-            normalizedOriginalName,
-            matchedName: match.matchedExercise.name,
-            matchedNameLower,
-          };
-
-          try {
-            const existingAlias = await ExerciseAlias.findOne(aliasFilter);
-
-            if (existingAlias) {
-              const updatePayload = { ...aliasPayload };
-
-              if (
-                existingAlias.confidenceScore === undefined ||
-                existingAlias.confidenceScore > confidenceScore
-              ) {
-                updatePayload.confidenceScore = confidenceScore;
-              }
-
-              await ExerciseAlias.findByIdAndUpdate(
-                existingAlias._id,
-                { $set: updatePayload },
-                { new: true }
-              );
-            } else {
-              await ExerciseAlias.create({ ...aliasPayload, confidenceScore });
-            }
-
-            console.log(
-              `Exercise alias saved: ${exercise.name} -> ${match.matchedExercise.name} (confidence: ${match.confidence.toFixed(3)})`
-            );
-          } catch (aliasError) {
-            console.error('Failed to persist exercise alias', aliasError);
-          }
-        } else if (match.matchType === 'alias') {
-          console.log(`Exercise alias reused: ${exercise.name} -> ${match.matchedExercise.name}`);
-        }
+        validatedExercises.push(sanitized);
       }
 
-      if (questIsValid) {
-        // 7. For validated quests, add metadata
-        const now = new Date();
-        const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
-
-        validatedQuests.push({
-          ...quest,
-          exercises: validatedExercises,
-          questId: uuidv4(),
-          createdAt: now,
-          expiresAt: expiresAt,
-          status: 'available',
-        });
+      if (!questIsValid) {
+        console.log(`Discarding quest "${quest.title}" because one or more exercises were invalid.`);
+        continue;
       }
+
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+      validatedQuests.push({
+        ...quest,
+        exercises: validatedExercises,
+        questId: uuidv4(),
+        createdAt: now,
+        expiresAt,
+        status: 'available',
+      });
     }
 
     console.log('--- Validated Quests ---');
     console.log(JSON.stringify(validatedQuests, null, 2));
 
-    // 8. Save quests to user
     const now = new Date();
-    // Filter out old available quests, keeping non-expired active/completed ones.
-    const questsToKeep = user.dailyQuests.filter(quest => quest.status !== 'available' && quest.expiresAt > now);
+    const questsToKeep = user.dailyQuests.filter(
+      (quest) => quest.status !== 'available' && quest.expiresAt > now
+    );
     user.dailyQuests = [...questsToKeep, ...validatedQuests];
-    user.markModified('dailyQuests'); // Explicitly mark the array as modified
+    user.markModified('dailyQuests');
     await user.save();
     console.log('--- Quests saved to user ---');
 
     return validatedQuests;
-
   } catch (error) {
     console.error('Error generating daily quests:', error);
-    // In a real app, you might want to return a user-friendly error or fallback quests
     return [];
   }
 };

--- a/frontend/src/components/QuestCompletionForm.jsx
+++ b/frontend/src/components/QuestCompletionForm.jsx
@@ -4,10 +4,11 @@ import { createPortal } from 'react-dom';
 const QuestCompletionForm = ({ quest, onSubmit, onClose }) => {
   const [loggedExercises, setLoggedExercises] = useState(
     quest.exercises.map(ex => ({
+      exerciseId: ex.exerciseId || null,
       name: ex.name,
       sets: ex.sets,
-      reps: ex.reps || null,
-      duration: ex.duration || null,
+      reps: ex.reps ?? null,
+      duration: ex.duration ?? null,
       weight: null,
     }))
   );


### PR DESCRIPTION
## Summary
- limit the quest generation prompt to a filtered, goal-aware pool of database exercises and require exerciseId outputs
- remove fuzzy matching logic in favour of direct exerciseId validation and persist the ids on daily quests
- update quest completion handling and the completion form to carry exercise ids through logging and XP processing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9d36a971c832eb9374281b8e78bfc