### PR TITLE
Feat/phase2 e2e auth smoke

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,9 @@ JWT_SECRET=replace_with_a_long_random_secret
 NODE_ENV=development
 # Comma-separated frontend origins for CORS
 CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# Test-only auth helper (must stay false outside local test runs)
+ENABLE_E2E_AUTH_HELPER=false
+E2E_TEST_EMAIL=e2e-user@example.com
+E2E_TEST_USERNAME=e2e-user
+E2E_TEST_PASSWORD=e2e-password-123

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,10 @@ if (process.env.NODE_ENV === 'production' && !process.env.JWT_SECRET) {
   throw new Error('JWT_SECRET is required in production.');
 }
 
+if (process.env.NODE_ENV === 'production' && process.env.ENABLE_E2E_AUTH_HELPER === 'true') {
+  throw new Error('ENABLE_E2E_AUTH_HELPER must never be enabled in production.');
+}
+
 const corsOptions = {
   origin(origin, callback) {
     if (!origin || allowedOrigins.includes(origin)) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@playwright/test": "^1.55.0",
         "@tailwindcss/postcss": "^4.1.10",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1199,6 +1200,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3449,6 +3466,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "test:e2e:smoke": "playwright test tests/e2e/smoke-bootstrap.spec.js tests/e2e/real-login.spec.js"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -27,6 +29,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "postcss": "^8.5.6",
+    "@playwright/test": "^1.55.0",
     "tailwindcss": "^4.1.10",
     "vite": "^6.3.5"
   }

--- a/frontend/playwright.config.cjs
+++ b/frontend/playwright.config.cjs
@@ -1,0 +1,14 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/e2e',
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: process.env.FRONTEND_BASE_URL || 'http://127.0.0.1:5173',
+    trace: 'retain-on-failure',
+  },
+  reporter: [['list']],
+});

--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -1,0 +1,34 @@
+# E2E Smoke Tests
+
+These tests cover Phase 2 authenticated UI access in two ways:
+
+- `real-login.spec.js`: exercises the real login UI flow.
+- `smoke-bootstrap.spec.js`: uses a test-only backend helper to bootstrap auth for faster protected-route smoke checks.
+
+## Required backend test flags
+
+Run backend with:
+
+- `NODE_ENV=test`
+- `ENABLE_E2E_AUTH_HELPER=true`
+
+Optional credential overrides:
+
+- `E2E_TEST_EMAIL`
+- `E2E_TEST_USERNAME`
+- `E2E_TEST_PASSWORD`
+
+## Run
+
+From `frontend/`:
+
+1. Install Playwright dependency and browser:
+   - `npm install`
+   - `npx playwright install`
+2. Run smoke suite:
+   - `npm run test:e2e:smoke`
+
+Optional URLs:
+
+- `FRONTEND_BASE_URL` (default `http://127.0.0.1:5173`)
+- `BACKEND_BASE_URL` (default `http://127.0.0.1:5000`)

--- a/frontend/tests/e2e/helpers/auth.js
+++ b/frontend/tests/e2e/helpers/auth.js
@@ -1,0 +1,31 @@
+import { expect } from '@playwright/test';
+
+const backendBaseUrl = process.env.BACKEND_BASE_URL || 'http://127.0.0.1:5000';
+const email = process.env.E2E_TEST_EMAIL || 'e2e-user@example.com';
+const username = process.env.E2E_TEST_USERNAME || 'e2e-user';
+const password = process.env.E2E_TEST_PASSWORD || 'e2e-password-123';
+
+export const e2eAuthConfig = {
+  backendBaseUrl,
+  email,
+  username,
+  password,
+};
+
+export async function bootstrapSession(request) {
+  const response = await request.post(
+    `${backendBaseUrl}/api/users/e2e/bootstrap-session`,
+    {
+      data: { email, username, password },
+    }
+  );
+
+  await expect(response, 'e2e auth helper must be enabled in backend test mode').toBeOK();
+
+  const payload = await response.json();
+  expect(payload.success).toBeTruthy();
+  expect(payload.token).toBeTruthy();
+  expect(payload.user?.id).toBeTruthy();
+  return payload;
+}
+

--- a/frontend/tests/e2e/real-login.spec.js
+++ b/frontend/tests/e2e/real-login.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { bootstrapSession, e2eAuthConfig } from './helpers/auth';
+
+test.describe('auth real login flow', () => {
+  test('logs in through UI and reaches protected guild route', async ({ page, request }) => {
+    // Seed deterministic credentials, then verify login using the real UI path.
+    const payload = await bootstrapSession(request);
+
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Login' }).first().click();
+    await page.locator('#login-email').fill(e2eAuthConfig.email);
+    await page.locator('#login-password').fill(e2eAuthConfig.password);
+    await page.locator('form').getByRole('button', { name: 'Login' }).click();
+
+    await expect(page.getByText('This is your base of operations. Visit the Guild or brave the Dungeon!')).toBeVisible();
+    await page.getByRole('button', { name: 'Guild' }).click();
+    await expect(page).toHaveURL(/\/guild$/);
+    await expect(page.getByRole('heading', { name: 'Guild' })).toBeVisible();
+    await expect(page.getByText(`Welcome, ${payload.user.username}!`)).toBeVisible();
+  });
+});
+

--- a/frontend/tests/e2e/smoke-bootstrap.spec.js
+++ b/frontend/tests/e2e/smoke-bootstrap.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { bootstrapSession, e2eAuthConfig } from './helpers/auth';
+
+test.describe('auth bootstrap smoke', () => {
+  test('bootstraps authenticated session and loads protected pages', async ({ page, request }) => {
+    const payload = await bootstrapSession(request);
+    const user = payload.user;
+    const token = payload.token;
+
+    await page.addInitScript(
+      ({ sessionUser, sessionToken }) => {
+        localStorage.setItem('currentUser', JSON.stringify(sessionUser));
+        localStorage.setItem('token', sessionToken);
+      },
+      { sessionUser: user, sessionToken: token }
+    );
+
+    // Prime root first so app initializes with localStorage-backed auth state.
+    await page.goto('/');
+    await expect(page.getByText('This is your base of operations. Visit the Guild or brave the Dungeon!')).toBeVisible();
+    await page.getByRole('button', { name: 'Guild' }).click();
+    await expect(page).toHaveURL(/\/guild$/);
+    await expect(page.getByRole('heading', { name: 'Guild' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'View Quest Board' })).toBeVisible();
+
+    const userResponse = await request.get(
+      `${e2eAuthConfig.backendBaseUrl}/api/users/${user.id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    await expect(userResponse).toBeOK();
+  });
+});
+


### PR DESCRIPTION
Summary:

- Add test-gated backend endpoint POST /api/users/e2e/bootstrap-session for deterministic auth bootstrap.
- Add production guardrail preventing ENABLE_E2E_AUTH_HELPER=true in production.
- Add Playwright smoke suite for real-login and bootstrap-auth protected-route flow.